### PR TITLE
chore: remove javax.annotation.Generated dependency

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -60,7 +60,6 @@ errorProneCoreVersion=2.42.0
 deployerVersion=0.5.2
 
 # Others
-javaxValidationApiVersion=1.3.2
 # https://github.com/DanielLiu1123/classpath-replacer
 classpathReplacerVersion=3.2.0
 

--- a/gradle/protobuf-with-pgv.gradle
+++ b/gradle/protobuf-with-pgv.gradle
@@ -14,9 +14,7 @@ protobuf {
     }
     generateProtoTasks {
         all()*.plugins {
-            grpc {
-                option '@generated=omit'
-            }
+            grpc {}
             javapgv {
                 option "lang=java"
             }

--- a/gradle/protobuf.gradle
+++ b/gradle/protobuf.gradle
@@ -11,9 +11,7 @@ protobuf {
     }
     generateProtoTasks {
         all()*.plugins {
-            grpc {
-                option '@generated=omit'
-            }
+            grpc {}
         }
     }
 }

--- a/grpc-starter-dependencies/build.gradle
+++ b/grpc-starter-dependencies/build.gradle
@@ -36,7 +36,6 @@ dependencies {
         // grpc related dependencies
         api("com.google.api:api-common:${googleApiCommonVersion}")
         api("com.google.api.grpc:proto-google-common-protos:${protoGoogleCommonProtosVersion}")
-        api("javax.annotation:javax.annotation-api:${javaxValidationApiVersion}") // for using javax.annotation.Generated
     }
 
     api(platform("io.grpc:grpc-bom:${grpcVersion}"))


### PR DESCRIPTION
Since [grpc-java v1.74.0](https://github.com/grpc/grpc-java/releases/tag/v1.74.0), `@generated=omit` is the default behavior, the compiler no longer emits `@javax.annotation.Generated` unless explicitly opted in. There is no reason for `grpc-starter-dependencies` to manage `javax.annotation:javax.annotation-api` anymore.